### PR TITLE
Allow arrays in extract

### DIFF
--- a/lib/text_rank.rb
+++ b/lib/text_rank.rb
@@ -20,7 +20,7 @@ module TextRank
   autoload :VERSION,            'text_rank/version'
 
   # A convenience method for quickly extracting keywords from text with default options
-  # @param text [String] text from which to extract keywords
+  # @param text [String,Array<String>] text from which to extract keywords
   # @option (see KeywordExtractor.basic)
   # @return [Hash<String, Float>] of tokens and text rank (in descending order)
   def self.extract_keywords(text, **options)

--- a/lib/text_rank/version.rb
+++ b/lib/text_rank/version.rb
@@ -1,6 +1,6 @@
 module TextRank
 
   # Current gem version
-  VERSION = '1.2.4'
+  VERSION = '1.2.5'
 
 end

--- a/spec/text_rank/keyword_extractor_spec.rb
+++ b/spec/text_rank/keyword_extractor_spec.rb
@@ -97,6 +97,44 @@ describe TextRank::KeywordExtractor do
     end
   end
 
+  it 'extracts from array of text' do
+    ranks = TextRank::KeywordExtractor.new.extract([<<~TEST1, <<~TEST2, <<~TEST3])
+      In a castle of Westphalia, belonging to the Baron of Thunder-ten-Tronckh, lived
+      a youth, whom nature had endowed with the most gentle manners.
+    TEST1
+      His countenance was a true picture of his soul. He combined a true judgment
+      with simplicity of spirit, which was the reason, I apprehend, of his being
+      called Candide.
+    TEST2
+      The old servants of the family suspected him to have been the son of the
+      Baron's sister, by a good, honest gentleman of the neighborhood, whom that
+      young lady would never marry because he had been able to prove only seventy-one
+      quarterings, the rest of his genealogical tree having been lost through the
+      injuries of time.
+    TEST3
+    # These numbers should be slightly different than if we concatenated the strings
+    # together because we will avoid building graph edges between the boundary tokens
+    # (those tokens at the beginning or end of each text in the array).
+    # We expect to get close to this (but not exact)
+    {
+      'of'                  => 0.08111182819064046,
+      'the'                 => 0.07321447571708903,
+      'a'                   => 0.04162826286773359,
+      'his'                 => 0.026669570973517784,
+      'been'                => 0.02628220013248464,
+      'to'                  => 0.02589186762286176,
+      'whom'                => 0.01884269632501968,
+      'had'                 => 0.018692069918838462,
+      'with'                => 0.01818822350109298,
+      'true'                => 0.01777124221769915,
+      'was'                 => 0.01771751823245395,
+      'Baron'               => 0.017189650358858617,
+      # Testing the first 12 is sufficient for this spec
+    }.each do |k, v|
+      expect(ranks[k]).to be_within(0.0001).of(v)
+    end
+  end
+
   it 'advanced tokenizer' do
     extractor = TextRank::KeywordExtractor.advanced
     tokens = extractor.tokenize(<<~TEST)

--- a/spec/text_rank_spec.rb
+++ b/spec/text_rank_spec.rb
@@ -5,8 +5,12 @@ describe TextRank do
     expect(TextRank::VERSION).not_to be nil
   end
 
-  specify 'TextRank.extract_keywords' do
+  specify 'TextRank.extract_keywords(String)' do
     expect(TextRank.extract_keywords('The man went to town and found the town empty').keys).to eq(%w[went town man])
+  end
+
+  specify 'TextRank.extract_keywords(Array)' do
+    expect(TextRank.extract_keywords(['The man went to town and found the town empty', 'Apples and Oranges.', 'The town had apples.']).keys).to eq(%w[town went apples man oranges])
   end
 
   specify 'TextRank.extract_keywords_advanced' do

--- a/text_rank.gemspec
+++ b/text_rank.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov', '~> 0.17.0' # 0.18 not supported by code climate
+  spec.add_development_dependency 'yard'
 
   spec.add_development_dependency 'engtagger' # Optional runtime dependency but needed for specs
   spec.add_development_dependency 'nokogiri'  # Optional runtime dependency but needed for specs


### PR DESCRIPTION
When processing multiple documents it may not be advisable to concatenate the text together into one single large piece of text.  This is because the tokens on the boundary (those at the beginning/end of each document) will have graph edges added to tokens accross the boundary into the other document, creating a false contextual relationship between them.

But because it may be desirable to pass multiple documents into the extractor to obtain a unified ranking across the documents, we will add support for passing in an array of text into the extractor which will provide slightly different values than if the concatenated text were passed in.